### PR TITLE
Split large methods into smaller methods and add a test

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,17 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "type": "cargo",
+            "subcommand": "test",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
         }
     ]
 }


### PR DESCRIPTION
Split the two huge methods (one in slack.rs and one in github.rs) into smaller methods. This will make future unit testing easier. Also add a unit test for the `comma_separate_list` function as a trivial example, so we can exercise our CI unit testing in this repo.