### PR TITLE
add build monitoring / badge for master branch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,16 @@
+name: Master Build
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Slack Github Digest
+![](https://github.com/waf/slack-github-digest/workflows/Master%20Build/badge.svg)
 
 Post a digest of your GitHub followers' open-source contributions to slack! Written in Rust.
 


### PR DESCRIPTION
Add GitHub Actions configuration to monitor the `master` branch for build failures. Also include a badge in the README for this build.